### PR TITLE
u-boot-script-gateworks-imx.bb: Fix license checksum

### DIFF
--- a/recipes-bsp/u-boot/u-boot-script-gateworks-imx.bb
+++ b/recipes-bsp/u-boot/u-boot-script-gateworks-imx.bb
@@ -1,5 +1,5 @@
 LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
 DEPENDS = "u-boot-mkimage-native"
 
 SRC_URI = "file://6x_bootscript-yocto.txt"


### PR DESCRIPTION
GPL-3.0 was renamed to GPL-3.0-only by commit 2456f523 of oe-core

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>