### PR TITLE
layer.conf: update for the whinlatter release series

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS += "freescale-3rdparty"
 BBFILE_PATTERN_freescale-3rdparty := "^${LAYERDIR}/"
 BBFILE_PRIORITY_freescale-3rdparty = "4"
 
-LAYERSERIES_COMPAT_freescale-3rdparty = "styhead walnascar"
+LAYERSERIES_COMPAT_freescale-3rdparty = "walnascar whinlatter"
 LAYERDEPENDS_freescale-3rdparty = "core freescale-layer"


### PR DESCRIPTION
Fix current error:
ERROR: Layer freescale-3rdparty is not compatible with the core layer which only supports these series: whinlatter (layer is compatible with styhead walnascar)